### PR TITLE
filter tools with invalid / missing data

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
     <body>
         <div data-id="OEBD00200000P4" toTable="true" class="benchmarkingChart_scatter" data-mode="dev"></div>
+        <div data-id="OEBD00200001HQ" toTable="true" class="benchmarkingChart_scatter" data-mode="dev"></div>
         <div data-id="invalid-id-here" toTable="true" class="benchmarkingChart_scatter" data-mode="dev"></div>
     </body>
     

--- a/src/app.js
+++ b/src/app.js
@@ -170,6 +170,8 @@ function join_all_json(result, divid, metric_x, metric_y,metrics_names, better){
       jo['y'] = element.metric_y;
       jo['e_y'] = element.stderr_y ? parseFloat(element.stderr_y) : 0;
       jo['e_x'] = element.stderr_x ? parseFloat(element.stderr_x) : 0;
+      jo['valid'] = (element.metric_y < 10000);
+      if (!jo['valid']){ jo['e_y'] = 0; }
       full_json.push(jo); 
 
     });

--- a/src/chart_coordinates.js
+++ b/src/chart_coordinates.js
@@ -4,7 +4,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   // Add Y Axis Error Line
   svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("class", "error-line")
       .attr("id", function (d) { return divid+"___line"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("x1", function(d) {
@@ -23,7 +23,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   // Add X Axis Error Line
   svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("class", "error-line")
       .attr("id", function (d) { return divid+"___lineX"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("x1", function(d) {
@@ -42,7 +42,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   // Add Error Top Cap
   svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("id", function (d) { return divid+"___top"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("class", "error-cap")
       .attr("x1", function(d) {
@@ -61,7 +61,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   // Add Error Bottom Cap
   svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("id", function (d) { return divid+"___bottom"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("class", "error-cap")
       .attr("x1", function(d) {
@@ -80,7 +80,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   // add right error cap
   svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("class", "error-cap")
       .attr("id", function (d) { return divid+"___right"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("x1", function(d) {
@@ -99,7 +99,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
     // add left error cap
     svg.append("g").selectAll("line")
       .data(data).enter()
-      .append("line")
+      .append("line").filter(function(d){ return d.valid; })
       .attr("class", "error-cap")
       .attr("id", function (d) { return divid+"___left"+d.toolname.replace(/[\. ()/-]/g, "_");})
       .attr("x1", function(d) {
@@ -124,7 +124,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   let dots =svg.selectAll(".dots")
     .data(data)
     .enter()
-    .append("path")
+    .append("path").filter(function(d){ return d.valid; })
     .attr("class", "benchmark_path");
   
   dots.attr("d", symbol.type(function(){return d3.symbolSquare}))

--- a/src/scatter_plot.js
+++ b/src/scatter_plot.js
@@ -9,10 +9,10 @@ export function createChart (data,divid, classification_type, metric_x, metric_y
     width = Math.round($(window).width()* 0.6818) - margin.left - margin.right,
     height = Math.round($(window).height()* 0.87) - margin.top - margin.bottom;
 
-  let min_x = d3.min(data, function(d) { return d.x; });
-  let max_x = d3.max(data, function(d) { return d.x; });
-  let min_y = d3.min(data, function(d) { return d.y; });
-  let max_y = d3.max(data, function(d) { return d.y; });
+  let min_x = d3.min(data, function(d) { return d.valid ? d.x : NaN; });
+  let max_x = d3.max(data, function(d) { return d.valid ? d.x : NaN; });
+  let min_y = d3.min(data, function(d) { return d.valid ? d.y : NaN; });
+  let max_y = d3.max(data, function(d) { return d.valid ? d.y : NaN; });
 
   //the x axis domain is calculated based in the difference between the max and min, and the average stderr (BETA)
   var proportion = get_avg_stderr(data, "x")/(max_x-min_x);


### PR DESCRIPTION
this PR filters tools with missing data (e.g. in "OEBD00200001HQ", no trees sampled for Proteinortho). adds boolean `valid` attribute to each datapoint. currently set by checking un-reasonable y-metric, but should be populated by the api in the future.
