### PR TITLE
fix replacement regex from tool-name to IDs

### DIFF
--- a/src/chart_coordinates.js
+++ b/src/chart_coordinates.js
@@ -8,7 +8,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
       .attr("class", "error-line")
       .attr("stroke", "black")
       .style("stroke-dasharray", ("2, 2"))
-      .attr("id", function (d) { return divid+"___line"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___line"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("x1", function(d) {
         return xScale(d.x);
       })
@@ -29,7 +29,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
       .attr("class", "error-line")
       .attr("stroke", "black")
       .style("stroke-dasharray", ("2, 2"))
-      .attr("id", function (d) { return divid+"___lineX"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___lineX"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("x1", function(d) {
         return xScale(d.x - d.e_x);
       })
@@ -47,7 +47,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   svg.append("g").selectAll("line")
       .data(data).enter()
       .append("line")
-      .attr("id", function (d) { return divid+"___top"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___top"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("class", "error-cap")
       .attr("stroke", "black")
       .style("stroke-width", "1px")
@@ -68,7 +68,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
   svg.append("g").selectAll("line")
       .data(data).enter()
       .append("line")
-      .attr("id", function (d) { return divid+"___bottom"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___bottom"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("class", "error-cap")
       .attr("stroke", "black")
       .style("stroke-width", "1px")
@@ -92,7 +92,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
       .attr("class", "error-cap")
       .attr("stroke", "black")
       .style("stroke-width", "1px")
-      .attr("id", function (d) { return divid+"___right"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___right"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("x1", function(d) {
         return xScale(d.x + d.e_x);
       })
@@ -113,7 +113,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
       .attr("class", "error-cap")
       .attr("stroke", "black")
       .style("stroke-width", "1px")
-      .attr("id", function (d) { return divid+"___left"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) { return divid+"___left"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("x1", function(d) {
         return xScale(d.x - d.e_x);
       })
@@ -145,7 +145,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
             .range(Array(Math.ceil(data.length/7)).fill([d3.symbolCircle, d3.symbolCross, d3.symbolDiamond, d3.symbolSquare, d3.symbolStar, d3.symbolTriangle, d3.symbolWye]).flat());
 
     dots.attr("d", symbol.type(function(d){return shapeScale(d.toolname)}).size(Math.round($(window).height()* 0.2)))
-      .attr("id", function (d) {  return divid+"___"+d.toolname.replace(/[\. ()/-]/g, "_");})
+      .attr("id", function (d) {  return divid+"___"+d.toolname.replace(/[\. ()+/-]/g, "_");})
       .attr("class","line")
       .attr('transform',function(d){ return "translate("+xScale(d.x)+","+yScale(d.y)+")"; })
       .attr("r", 6)
@@ -154,7 +154,7 @@ export function append_dots_errobars (svg, data, xScale, yScale, div, cValue, co
       })
       .on("mouseover", function(d) {
         // show tooltip only if the tool is visible
-        let ID = divid+"___"+d.toolname.replace(/[\. ()/-]/g, "_");
+        let ID = divid+"___"+d.toolname.replace(/[\. ()+/-]/g, "_");
         if (metric_x.startsWith("OEBM") == true){
           var txt_x = metrics_names[metric_x];
         } else if ( metric_x in metrics_names) {

--- a/src/legend.js
+++ b/src/legend.js
@@ -23,20 +23,20 @@ export function draw_legend (data, svg, xScale, yScale, div, width, height, remo
       .style("fill", color)
         .attr("d", symbol.type(function(d){return shapeScale(d)}).size(Math.round($(window).height()* 0.22)))
         .attr("transform", function(d, i) { return "translate(" + (width+25+i%n*(Math.round($(window).width()* 0.0002))) + "," + (Math.round($(window).height()* 0.01)) +  ")"; })
-        .attr("id", function (d) { return divid+"___leg_symbol"+d.replace(/[\. ()/-]/g, "_");});
+        .attr("id", function (d) { return divid+"___leg_symbol"+d.replace(/[\. ()+/-]/g, "_");});
 
     // draw legend colored rectangles
     legend.append("rect")
           .attr("x", width + Math.round($(window).width()* 0.010227))
           .attr("width", Math.round($(window).width()* 0.010227))
           .attr("height", Math.round($(window).height()* 0.020833))
-          .attr("id", function (d) { return divid+"___leg_rect"+d.replace(/[\. ()/-]/g, "_");})
+          .attr("id", function (d) { return divid+"___leg_rect"+d.replace(/[\. ()+/-]/g, "_");})
           .attr("class", "benchmark_legend_rect")
           .style("fill", "transparent")
           .attr("z-index", 3)
           .on('click', function(d) {
             
-            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()/-]/g, "_"));
+            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()+/-]/g, "_"));
             let ID = dot._groups[0][0].id;
   
             if(data.length-removed_tools.length-1 >= 4){
@@ -68,7 +68,7 @@ export function draw_legend (data, svg, xScale, yScale, div, width, height, remo
           })
           .on("mouseover", function (d) {
   
-            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()/-]/g, "_"));
+            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()+/-]/g, "_"));
             let ID = dot._groups[0][0].id;
             let tool_id =ID.split("___")[1];
   
@@ -85,7 +85,7 @@ export function draw_legend (data, svg, xScale, yScale, div, width, height, remo
           }) 
           .on("mouseout", function (d) {
   
-            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()/-]/g, "_"));
+            let dot = d3.select("text#" +divid+"___"+d.replace(/[\. ()+/-]/g, "_"));
             let ID = dot._groups[0][0].id;
             let tool_id =ID.split("___")[1];
   
@@ -104,7 +104,7 @@ export function draw_legend (data, svg, xScale, yScale, div, width, height, remo
     legend.append("text")
           .attr("x", width + Math.round($(window).width()* 0.028))
           .attr("y", Math.round($(window).height()* 0.01041))
-          .attr("id", function (d) { return divid+"___"+d.replace(/[\. ()/-]/g, "_");})
+          .attr("id", function (d) { return divid+"___"+d.replace(/[\. ()+/-]/g, "_");})
           .attr("dy", ".35em")
           .style("text-anchor", "start")
           .style("font-size", "1vw")

--- a/src/remove_tools.js
+++ b/src/remove_tools.js
@@ -4,7 +4,7 @@ export function remove_hidden_tools(data, removed_tools){
   // create a new array where the tools that have not been hidden will be stored
   let tools_not_hidden = [];
   data.forEach(element => {
-    let index = $.inArray(element.toolname.replace(/[\. ()/_]/g, "-"), removed_tools);
+    let index = $.inArray(element.toolname.replace(/[\. ()+/_]/g, "-"), removed_tools);
     if (index == -1){
       tools_not_hidden.push(element);
     }

--- a/src/table.js
+++ b/src/table.js
@@ -12,9 +12,9 @@ export function fill_in_table (divid, data, all_participants, removed_tools){
     row.insertCell(0).innerHTML = element.toolname;
     //if the participant is not hidden the 2nd column is filled with the corresponding quartile
     // if not it is filled with --
-    if ($.inArray(element.toolname.replace(/[\. ()/_]/g, "-"), removed_tools) == -1) {
+    if ($.inArray(element.toolname.replace(/[\. ()+/_]/g, "-"), removed_tools) == -1) {
       // var quartile;
-      let obj = data.find(o => o.toolname.replace(/[\. ()/_]/g, "-") === element.toolname.replace(/[\. ()/_]/g, "-"));
+      let obj = data.find(o => o.toolname.replace(/[\. ()+/_]/g, "-") === element.toolname.replace(/[\. ()/_]/g, "-"));
       row.insertCell(1).innerHTML = obj.quartile;
     } else {
       row.insertCell(1).innerHTML = "--";
@@ -22,7 +22,7 @@ export function fill_in_table (divid, data, all_participants, removed_tools){
     
     // add id
     var my_cell = row.cells[0];
-    my_cell.id = divid+"___cell"+element.toolname.replace(/[\. ()/-]/g, "_");
+    my_cell.id = divid+"___cell"+element.toolname.replace(/[\. ()+/-]/g, "_");
 
     my_cell.addEventListener('click', function (d) {
 
@@ -87,9 +87,9 @@ export function set_cell_colors(divid, legend_color_palette, removed_tools){
       $(this).css({'background' : '#edf8e9'}); 
     } else if (cell_value == "--") {
       $(this).css({'background' : '#f0f0f5'}); 
-    } else if ($.inArray(cell_value, tools) > -1 && $.inArray(cell_value.replace(/[\. ()/_]/g, "-"), removed_tools) == -1) {
+    } else if ($.inArray(cell_value, tools) > -1 && $.inArray(cell_value.replace(/[\. ()+/_]/g, "-"), removed_tools) == -1) {
       $(this).css({'background' : 'linear-gradient(to left, white 92%, ' + legend_color_palette[cell_value] + ' 8%)'});
-    } else if ($.inArray(cell_value.replace(/[\. ()/_]/g, "-"), removed_tools) > -1) {
+    } else if ($.inArray(cell_value.replace(/[\. ()+/_]/g, "-"), removed_tools) > -1) {
       $(this).css({ 'background' : 'linear-gradient(to left, white 92%, ' + legend_color_palette[cell_value] + ' 8%)', 'opacity': 0.5});
       $(this).closest("tr").css('opacity', 0.5);
     } else {

--- a/src/table.js
+++ b/src/table.js
@@ -14,7 +14,7 @@ export function fill_in_table (divid, data, all_participants, removed_tools){
     // if not it is filled with --
     if ($.inArray(element.toolname.replace(/[\. ()+/_]/g, "-"), removed_tools) == -1) {
       // var quartile;
-      let obj = data.find(o => o.toolname.replace(/[\. ()+/_]/g, "-") === element.toolname.replace(/[\. ()/_]/g, "-"));
+      let obj = data.find(o => o.toolname.replace(/[\. ()+/_]/g, "-") === element.toolname.replace(/[\. ()+/_]/g, "-"));
       row.insertCell(1).innerHTML = obj.quartile;
     } else {
       row.insertCell(1).innerHTML = "--";


### PR DESCRIPTION
the current regex to replace illegal characters from a toolname to an ID is missing the '+' character. As of now, tools with a + in it's name cannot be selected and deactivated on the plot. 

This PR simply adds the + character to the regex in the various places where the a name is converted to an ID.
