### PR TITLE
fix missing data in plots

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
     <body>
         <div data-id="OEBD00200001HD" toTable="true" class="benchmarkingChart_scatter" data-api-url="https://dev-openebench.bsc.es/api/scientific/graphql"></div>
+        <div data-id="OEBD00200002UO" toTable="true" class="benchmarkingChart_scatter" default-zoom="on" data-api-url="https://openebench.bsc.es/api/scientific/graphql" metric_x="NR_COMPLETED_TREE_SAMPLINGS" metric_y="RF_DISTANCE"></div>
         <div data-id="invalid-id-here" toTable="true" class="benchmarkingChart_scatter" data-api-url="https://dev-openebench.bsc.es/api/scientific/graphql"></div>
     </body>
 

--- a/src/app.js
+++ b/src/app.js
@@ -217,6 +217,12 @@ function join_all_json(result, divid, metric_x, metric_y, metrics_names, better)
 
             let jo = {};
             jo['toolname'] = short_name;
+            if (element.metric_x == 999999 && element.metric_x == 999999){
+                element.metric_x = NaN; element.stderr_x = NaN;
+            }
+            if (element.metric_y == 999999 && element.metric_y == 999999){
+                element.metric_y = NaN; element.stderr_y = NaN;
+            }
             jo['x'] = element.metric_x;
             jo['y'] = element.metric_y;
             jo['e_y'] = element.stderr_y ? parseFloat(element.stderr_y) : 0;


### PR DESCRIPTION
The LUCA benchmark from G_STD2 QFO benchmark has one method which does not predict any results. this patch does hide the result of the methods that have no data by setting the x and y metric to NaN. 

